### PR TITLE
オウム返しをやめる

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -53,6 +53,8 @@ class WebhookController < ApplicationController
     when /\/一覧/
       logger.info "一覧に入りました"
       text = create_list_message(boxId: room_id)
+    else
+      return
     end
     message = {
       type: "text",

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -53,10 +53,6 @@ class WebhookController < ApplicationController
     when /\/一覧/
       logger.info "一覧に入りました"
       text = create_list_message(boxId: room_id)
-    when /\/ランダム/, /\/お店/, /\/見る/
-      #todo
-    else
-      text = "オウム返し！ ： " + received_message
     end
     message = {
       type: "text",


### PR DESCRIPTION
## 実装の背景・目的
2人以上のLINEのトークルームに参加し利用されることを前提にしているため、デバッグ用に実装していた
オウム返しを削除した

## やったこと

- [オウム返し処理](https://github.com/Hotsukai/intern-line-bot/commit/d5ac57fade1e870cee81579539ecbb22ef8f881b#diff-84ce946b570b0d6f2a5666c567e7d01ccd2d29f66d7b7bef050ce47dfeddd96bL56-L59)の削除