### PR TITLE
Feature/generate spot

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -53,10 +53,6 @@ class WebhookController < ApplicationController
     when /\/一覧/
       logger.info "一覧に入りました"
       text = create_list_message(boxId: room_id)
-    when /\/ランダム/, /\/お店/, /\/見る/
-      #todo
-    else
-      text = "オウム返し！ ： " + received_message
     end
     message = {
       type: "text",


### PR DESCRIPTION
## 実装の背景・目的
JSONboxからレコードを削除する際に、
`DELETE https://jsonbox.io/${boxId}?q=${クエリ}`
あるいは
`DELETE https://jsonbox.io/${boxId}/${レコードID}}`
を叩く必要がある。
- 前者の場合ユーザーから送信される日本語の文字列だとうまく動作しなかった。
- 後者の場合一度レコードを取得する必要がある

ことから、フィールドに新たにスポット名をハッシュ化した*spotId*をもたせることにした。

## やったこと

- generateIdメソッド作成
- レコードの追加時にフィールドにspotIdを追加で入れることにした。
