### PR TITLE
使い方を送信

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -31,22 +31,25 @@ class WebhookController < ApplicationController
 
     events = client.parse_events_from(body)
     events.each do |event|
-      logger.debug "***********************************************************"
+      talk_id = event["source"]["groupId"]
+      talk_id ||= event["source"]["roomId"]
+      talk_id ||= event["source"]["userId"]
+
       case event
       when Line::Bot::Event::Message
         case event.type
         when Line::Bot::Event::MessageType::Text
-          send_reply_to_text_message_handler(event.message["text"], event["source"]["roomId"], event["replyToken"])
+          send_reply_to_text_message_handler(event.message["text"], talk_id, event["replyToken"])
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
           response = client.get_message_content(event.message["id"])
           tf = Tempfile.open("content")
           tf.write(response.body)
         end
       when Line::Bot::Event::Join
-        logger.info("how"+HOW_TO_USE_MESSAGE)
+        logger.info("how" + HOW_TO_USE_MESSAGE)
         message = {
           type: "text",
-          text: "グループに招待ありがとうございます！\n"+HOW_TO_USE_MESSAGE,
+          text: "グループに招待ありがとうございます！\n" + HOW_TO_USE_MESSAGE,
         }
         response　 = client.reply_message(event["replyToken"], message)
         logger.info "メッセージを送信しました。: #{message[:text]}"
@@ -57,22 +60,22 @@ class WebhookController < ApplicationController
 
   private
 
-  def send_reply_to_text_message_handler(received_message, room_id, reply_token)
+  def send_reply_to_text_message_handler(received_message, talk_id, reply_token)
     # TODO グループでない場合の処理
     case received_message
     when /\/追加.+/u
       spot_name = received_message.sub(/\/追加/u, "").strip
       logger.info "追加に入りました"
-      save_to_jsonbox(spot_name, boxId: room_id)
+      save_to_jsonbox(spot_name, boxId: talk_id)
       text = "#{spot_name} を追加しました"
     when /\/削除.+/u
       spot_name = received_message.sub(/\/削除/u, "").strip
       logger.info "削除に入りました"
-      remove_from_jsonbox(spot_name, boxId: room_id)
+      remove_from_jsonbox(spot_name, boxId: talk_id)
       text = "#{spot_name} を削除しました"
     when /\/一覧/
       logger.info "一覧に入りました"
-      text = create_list_message(boxId: room_id)
+      text = create_list_message(boxId: talk_id)
     else
       return
     end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -6,13 +6,15 @@ require "json"
 class WebhookController < ApplicationController
   protect_from_forgery except: [:callback] # CSRF対策無効化
   JSON_BOX_ROOT_URL = "https://jsonbox.io/"
-  HOW_TO_USE_MESSAGE = "このBotではスラッシュコマンドを使うことで、個人チャット・トークルーム・グループごとに行きたいところリストを作成する事ができます。
+  HOW_TO_USE_MESSAGE = <<EOS
+このBotではスラッシュコマンドを使うことで、個人チャット・トークルーム・グループごとに行きたいところリストを作成する事ができます。
 【行きたいところリストに追加】
 /追加 場所の名前
 【行きたいところリストから削除】
 /削除 場所の名前
 【行きたいところリストを見る。】
-/一覧"
+/一覧
+EOS
 
   def client
     @client ||= Line::Bot::Client.new { |config|
@@ -31,9 +33,8 @@ class WebhookController < ApplicationController
 
     events = client.parse_events_from(body)
     events.each do |event|
-      talk_id = event["source"]["groupId"]
-      talk_id ||= event["source"]["roomId"]
-      talk_id ||= event["source"]["userId"]
+      source = event["source"]
+      talk_id = source["groupId"] || source["roomId"] || source["userId"]
 
       case event
       when Line::Bot::Event::Message

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -46,13 +46,7 @@ class WebhookController < ApplicationController
           tf.write(response.body)
         end
       when Line::Bot::Event::Join
-        logger.info("how" + HOW_TO_USE_MESSAGE)
-        message = {
-          type: "text",
-          text: "グループに招待ありがとうございます！\n" + HOW_TO_USE_MESSAGE,
-        }
-        response　 = client.reply_message(event["replyToken"], message)
-        logger.info "メッセージを送信しました。: #{message[:text]}"
+        send_text_message(event["replyToken"], "グループに招待ありがとうございます！\n" + HOW_TO_USE_MESSAGE)
       end
     end
     head :ok
@@ -79,6 +73,10 @@ class WebhookController < ApplicationController
     else
       return
     end
+    send_text_message(reply_token, text)
+  end
+
+  def send_text_message(reply_token, text)
     message = {
       type: "text",
       text: text,

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -6,7 +6,7 @@ require "json"
 class WebhookController < ApplicationController
   protect_from_forgery except: [:callback] # CSRF対策無効化
   JSON_BOX_ROOT_URL = "https://jsonbox.io/"
-  HOW_TO_USE_MESSAGE = "このBotではスラッシュコマンドを使うことで、トークルーム・グループごとに行きたいところリストを作成する事ができます。
+  HOW_TO_USE_MESSAGE = "このBotではスラッシュコマンドを使うことで、個人チャット・トークルーム・グループごとに行きたいところリストを作成する事ができます。
 【行きたいところリストに追加】
 /追加 場所の名前
 【行きたいところリストから削除】
@@ -47,6 +47,8 @@ class WebhookController < ApplicationController
         end
       when Line::Bot::Event::Join
         send_text_message(event["replyToken"], "グループに招待ありがとうございます！\n" + HOW_TO_USE_MESSAGE)
+      when Line::Bot::Event::Follow
+        send_text_message(event["replyToken"], "友だち追加ありがとうございます！\n" + HOW_TO_USE_MESSAGE)
       end
     end
     head :ok

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -59,19 +59,22 @@ class WebhookController < ApplicationController
   def send_reply_to_text_message_handler(received_message, talk_id, reply_token)
     # TODO グループでない場合の処理
     case received_message
-    when /\/追加.+/u
+    when /^\/追加.+/u
       spot_name = received_message.sub(/\/追加/u, "").strip
       logger.info "追加に入りました"
       save_to_jsonbox(spot_name, boxId: talk_id)
       text = "#{spot_name} を追加しました"
-    when /\/削除.+/u
+    when /^\/削除.+/u
       spot_name = received_message.sub(/\/削除/u, "").strip
       logger.info "削除に入りました"
       remove_from_jsonbox(spot_name, boxId: talk_id)
       text = "#{spot_name} を削除しました"
-    when /\/一覧/
+    when /^\/一覧/
       logger.info "一覧に入りました"
       text = create_list_message(boxId: talk_id)
+    when /^\//
+      logger.info "スラッシュエラーに入りました"
+      text = "※コマンドが間違っています※\n" + HOW_TO_USE_MESSAGE
     else
       return
     end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -45,11 +45,16 @@ class WebhookController < ApplicationController
   def send_reply_to_text_message_handler(received_message, room_id, reply_token)
     # TODO グループでない場合の処理
     case received_message
-    when /\/追加 .+/u
-      spot_name = received_message.sub(/\/追加/u, "")
+    when /\/追加.+/u
+      spot_name = received_message.sub(/\/追加/u, "").strip
       logger.info "追加に入りました"
       save_to_jsonbox(spot_name, boxId: room_id)
       text = "#{spot_name} を追加しました"
+    when /\/削除.+/u
+      spot_name = received_message.sub(/\/削除/u, "").strip
+      logger.info "削除に入りました"
+      remove_from_jsonbox(spot_name, boxId: room_id)
+      text = "#{spot_name} を削除しました"
     when /\/一覧/
       logger.info "一覧に入りました"
       text = create_list_message(boxId: room_id)
@@ -62,14 +67,28 @@ class WebhookController < ApplicationController
     logger.info "メッセージを送信しました。: #{message[:text]}"
   end
 
+  def remove_from_jsonbox(spot_name, boxId:)
+    uri = build_box_uri(:boxId => boxId, :query_str => build_delete_query(spot_name))
+    logger.debug uri
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    request = Net::HTTP::Delete.new(uri.request_uri)
+    response = http.request(request)
+    logger.info("id:#{boxId}から#{spot_name}をdeleteしました。#{response.body}")
+  end
+
+  def build_delete_query(spot_name)
+    "?" + URI.encode("q=spotName:" + spot_name)
+  end
+
   # @return 一覧の文字列
   def create_list_message(boxId:)
     convert_wants_list_to_text(load_from_jsonbox(boxId: boxId))
   end
 
   def load_from_jsonbox(boxId:)
-    url = build_box_uri(boxId: boxId)
-    response = Net::HTTP.get_response(url)
+    uri = build_box_uri(boxId: boxId)
+    response = Net::HTTP.get_response(uri)
     spots_list = convert_to_json(response.body)
     logger.debug "jsonboxID: #{boxId} から: #{spots_list}を取得しました。#{response.code}"
     spots_list
@@ -79,9 +98,8 @@ class WebhookController < ApplicationController
   def save_to_jsonbox(data, boxId:)
     uri = build_box_uri(boxId: boxId)
     http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = uri.scheme === "https"
-
-    params = { spotname: data }
+    params = { spotName: data }
+    http.use_ssl = true
     headers = { "Content-Type" => "application/json" }
     http.post(uri.path, params.to_json, headers)
     logger.info("id:#{boxId}に#{params}をpostしました。")
@@ -91,13 +109,13 @@ class WebhookController < ApplicationController
     text = "【行きたいところ一覧】"
     #TODO 0件のときの処理
     spots.each do |spot|
-      text += "\n" + spot["spotname"]
+      text += "\n" + spot["spotName"]
     end
     text
   end
 
-  def build_box_uri(boxId:)
-    URI.parse(JSON_BOX_ROOT_URL + boxId)
+  def build_box_uri(boxId:, query_str: "")
+    URI.parse(JSON_BOX_ROOT_URL + boxId + query_str)
   end
 
   def convert_to_json(str)

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -6,6 +6,13 @@ require "json"
 class WebhookController < ApplicationController
   protect_from_forgery except: [:callback] # CSRF対策無効化
   JSON_BOX_ROOT_URL = "https://jsonbox.io/"
+  HOW_TO_USE_MESSAGE = "このBotではスラッシュコマンドを使うことで、トークルーム・グループごとに行きたいところリストを作成する事ができます。
+【行きたいところリストに追加】
+/追加 場所の名前
+【行きたいところリストから削除】
+/削除 場所の名前
+【行きたいところリストを見る。】
+/一覧"
 
   def client
     @client ||= Line::Bot::Client.new { |config|
@@ -35,6 +42,14 @@ class WebhookController < ApplicationController
           tf = Tempfile.open("content")
           tf.write(response.body)
         end
+      when Line::Bot::Event::Join
+        logger.info("how"+HOW_TO_USE_MESSAGE)
+        message = {
+          type: "text",
+          text: "グループに招待ありがとうございます！\n"+HOW_TO_USE_MESSAGE,
+        }
+        response　 = client.reply_message(event["replyToken"], message)
+        logger.info "メッセージを送信しました。: #{message[:text]}"
       end
     end
     head :ok


### PR DESCRIPTION
## 実装の背景・目的
使い方を知らないユーザにたいして使い方を知らせる必要があった。

## やったこと

- グループ参加時・トークルーム参加時・友だち追加時に使い方を送信するようになった。
- 行の先頭にスラッシュがついているが有効なコマンド出ないときにエラーを送信するようになった。
- グループ・個人チャットでも使えるようになった。

## 補足

- メッセージを絵文字でデコったほうがいいかもしれないです。
- 詳しいドキュメントを作ってリンクを送信も規模が大きくなったらありかなとおもいました
