### PR TITLE
サーバーサイドのエラーハンドリング

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -67,7 +67,7 @@ EOS
     when /^\/削除.+/u
       spot_name = received_message.sub(/\/削除/u, "").gsub(/　/," ").strip
       logger.info "削除に入りました"
-      if (remove_from_jsonbox(spot_name, boxId: talk_id))
+      if remove_from_jsonbox(spot_name, boxId: talk_id)
         text = "#{spot_name} を削除しました"
       else
         text = "削除できませんでした"
@@ -100,9 +100,8 @@ EOS
     http.use_ssl = true
     request = Net::HTTP::Delete.new(uri.request_uri)
     response = http.request(request)
-
-    logger.info("id:#{boxId}から#{spot_name}をdeleteしました。#{response.body.delete("^0-9").to_i}")
-    return response.body.delete("^0-9").to_i > 0
+    logger.debug("id:#{boxId}から#{spot_name}をdeleteしました")
+    response.body.delete("^0-9").to_i > 0
   end
 
   def build_delete_query(spot_name)


### PR DESCRIPTION
## 実装の背景・目的

有効なコマンドを打ったのに何らかの事情でメッセージが送信されない際にユーザーの不信感を減らすために修正を行いました
## やったこと
- callbackの中でbegin/rescueを実装
- 削除件数が0の際に削除できなかった旨を送信
## 補足
ほぼ初めてbegin/rescueをしたので実装方針があっているかわからないです。