### PR TITLE
クイックリプライ機能追加

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -74,13 +74,13 @@ EOS
       logger.info "追加に入りました"
       save_to_jsonbox(spot_name, boxId: talk_id)
       text = "#{spot_name} を追加しました"
-      send_template_message(reply_token, spot_name, flag: "add")
+      send_template_message(reply_token, spot_name, actions: { done: "追加", undo: "削除" })
       return
     when /^\/削除.+/u
       spot_name = received_message.sub(/\/削除/u, "").gsub(/　/, " ").strip
       logger.info "削除に入りました"
       remove_from_jsonbox(spot_name, boxId: talk_id)
-      send_template_message(reply_token, spot_name, flag: "remove")
+      send_template_message(reply_token, spot_name, actions: { done: "削除", undo: "追加" })
       return
     when /^\/全削除/
       logger.info "全削除に入りました"
@@ -101,13 +101,7 @@ EOS
     send_text_message(reply_token, text) #return text ->そとでsend
   end
 
-  def send_template_message(reply_token, spotname, flag:)
-    case flag
-    when "add"
-      actions = { done: "追加", undo: "削除" }
-    when "remove"
-      actions = { done: "削除", undo: "追加" }
-    end
+  def send_template_message(reply_token, spotname, actions:)
     message = {
       "type": "text",
       "text": "#{spotname}を#{actions[:done]}しました。",

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -74,13 +74,14 @@ EOS
       logger.info "追加に入りました"
       save_to_jsonbox(spot_name, boxId: talk_id)
       text = "#{spot_name} を追加しました"
-      # send_text_message(reply_token, text)
-      send_template_message(reply_token, spot_name)
+      send_template_message(reply_token, spot_name, flag: "add")
+      return
     when /^\/削除.+/u
       spot_name = received_message.sub(/\/削除/u, "").gsub(/　/, " ").strip
       logger.info "削除に入りました"
       remove_from_jsonbox(spot_name, boxId: talk_id)
-      text = "#{spot_name} を削除しました"
+      send_template_message(reply_token, spot_name, flag: "remove")
+      return
     when /^\/全削除/
       logger.info "全削除に入りました"
       remove_from_jsonbox("*", boxId: talk_id)
@@ -100,11 +101,16 @@ EOS
     send_text_message(reply_token, text) #return text ->そとでsend
   end
 
-  def send_template_message(reply_token, spotname)
-    logger.debug("template")
+  def send_template_message(reply_token, spotname, flag:)
+    case flag
+    when "add"
+      actions = { done: "追加", undo: "削除" }
+    when "remove"
+      actions = { done: "削除", undo: "追加" }
+    end
     message = {
       "type": "text",
-      "text": "#{spotname}を追加しました。",
+      "text": "#{spotname}を#{actions[:done]}しました。",
       "quickReply": {
         "items": [
           {
@@ -120,7 +126,7 @@ EOS
             "action": {
               "type": "message",
               "label": "取り消し",
-              "text": "/削除 #{spotname}",
+              "text": "/#{actions[:undo]} #{spotname}",
             },
           },
         ],

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -61,12 +61,14 @@ EOS
     # TODO グループでない場合の処理
     case received_message
     when /^\/追加.+/u
-      spot_name = received_message.sub(/\/追加/u, "").gsub(/　/," ").strip
+      spot_name = received_message.sub(/\/追加/u, "").gsub(/　/, " ").strip
       logger.info "追加に入りました"
       save_to_jsonbox(spot_name, boxId: talk_id)
       text = "#{spot_name} を追加しました"
+      # send_text_message(reply_token, text)
+      send_template_message(reply_token, spot_name)
     when /^\/削除.+/u
-      spot_name = received_message.sub(/\/削除/u, "").gsub(/　/," ").strip
+      spot_name = received_message.sub(/\/削除/u, "").gsub(/　/, " ").strip
       logger.info "削除に入りました"
       remove_from_jsonbox(spot_name, boxId: talk_id)
       text = "#{spot_name} を削除しました"
@@ -79,13 +81,46 @@ EOS
     else
       return
     end
-    send_text_message(reply_token, text)
+    send_text_message(reply_token, text) #return text ->そとでsend
+  end
+
+  def send_template_message(reply_token, spotname)
+    logger.debug("template")
+    message = {
+      "type": "text",
+      "text": "追加しました。",
+      "quickReply": {
+        "items": [
+          {
+                "type": "action",
+                "action": {
+                  "type": "message",
+                  "label": "一覧をみる",
+                  "text": "/一覧",
+                },
+              },
+          {
+                "type": "action",
+                "action": {
+                  "type": "message",
+                  "label": "取り消し",
+                  "text": "/削除 #{spotname}",
+                },
+              },
+        ],
+      },
+    }
+    response　 = client.reply_message(reply_token, message)
+    logger.info "テンプレートメッセージを送信しました。: #{response}"
   end
 
   def send_text_message(reply_token, text)
     message = {
       type: "text",
       text: text,
+      sender: {
+        name: "StoreSpot",
+      },
     }
     response　 = client.reply_message(reply_token, message)
     logger.info "メッセージを送信しました。: #{message[:text]}"

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -8,12 +8,21 @@ class WebhookController < ApplicationController
   JSON_BOX_ROOT_URL = "https://jsonbox.io/"
   HOW_TO_USE_MESSAGE = <<EOS
 このBotではスラッシュコマンドを使うことで、個人チャット・トークルーム・グループごとに行きたいところリストを作成する事ができます。
+
 【行きたいところリストに追加】
 /追加 場所の名前
+
 【行きたいところリストから削除】
 /削除 場所の名前
+
+【行きたいところリストから全て削除】
+/全削除
+
 【行きたいところリストを見る。】
 /一覧
+
+【使い方を見る】
+/使い方
 EOS
 
   def client
@@ -72,9 +81,16 @@ EOS
       logger.info "削除に入りました"
       remove_from_jsonbox(spot_name, boxId: talk_id)
       text = "#{spot_name} を削除しました"
+    when /^\/全削除/
+      logger.info "全削除に入りました"
+      remove_from_jsonbox("*", boxId: talk_id)
+      text = "リストから全てを削除しました"
     when /^\/一覧/
       logger.info "一覧に入りました"
       text = create_list_message(boxId: talk_id)
+    when /^\/使い方/, /^\/つかいかた/
+      logger.info "使い方に入りました"
+      text = HOW_TO_USE_MESSAGE
     when /^\//
       logger.info "スラッシュエラーに入りました"
       text = "※コマンドが間違っています※\n" + HOW_TO_USE_MESSAGE
@@ -92,21 +108,21 @@ EOS
       "quickReply": {
         "items": [
           {
-                "type": "action",
-                "action": {
-                  "type": "message",
-                  "label": "一覧をみる",
-                  "text": "/一覧",
-                },
-              },
+            "type": "action",
+            "action": {
+              "type": "message",
+              "label": "一覧をみる",
+              "text": "/一覧",
+            },
+          },
           {
-                "type": "action",
-                "action": {
-                  "type": "message",
-                  "label": "取り消し",
-                  "text": "/削除 #{spotname}",
-                },
-              },
+            "type": "action",
+            "action": {
+              "type": "message",
+              "label": "取り消し",
+              "text": "/削除 #{spotname}",
+            },
+          },
         ],
       },
     }

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -105,6 +105,9 @@ EOS
     message = {
       "type": "text",
       "text": "#{spotname}を#{actions[:done]}しました。",
+      "sender": {
+        "name": "StoreSpotWith!!",
+      },
       "quickReply": {
         "items": [
           {
@@ -135,7 +138,7 @@ EOS
       type: "text",
       text: text,
       sender: {
-        name: "StoreSpot",
+        name: "StoreSpotWith!!",
       },
     }
     response　 = client.reply_message(reply_token, message)

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -104,7 +104,7 @@ EOS
     logger.debug("template")
     message = {
       "type": "text",
-      "text": "追加しました。",
+      "text": "#{spotname}を追加しました。",
       "quickReply": {
         "items": [
           {


### PR DESCRIPTION
## 実装の背景・目的

ユーザー体験向上のために必要な機能を増やした。
## やったこと

- 追加後に取り消し・一覧表示のクイックリプライを実装
- 全削除機能を追加
- 使い方コマンドを実装

## キャプチャ
![Screenshot_20201127-101745](https://user-images.githubusercontent.com/45584045/100400506-2479f000-309a-11eb-91a2-8465ebc426d2.png)

